### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ qjoypad (4.3.1-3) UNRELEASED; urgency=medium
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
   * Use canonical URL in Vcs-Git.
+  * Update standards version to 4.5.0, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Thu, 07 May 2020 03:05:52 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ qjoypad (4.3.1-3) UNRELEASED; urgency=medium
 
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
+  * Use canonical URL in Vcs-Git.
 
  -- Debian Janitor <janitor@jelmer.uk>  Thu, 07 May 2020 03:05:52 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+qjoypad (4.3.1-3) UNRELEASED; urgency=medium
+
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Thu, 07 May 2020 03:05:52 +0000
+
 qjoypad (4.3.1-2) unstable; urgency=medium
 
   * Use https:// for the copyright format.

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Build-Depends: cmake,
                pkg-config,
                qtbase5-dev,
                qttools5-dev
-Standards-Version: 4.4.1
+Standards-Version: 4.5.0
 Rules-Requires-Root: no
 Homepage: https://github.com/panzi/qjoypad
 Vcs-Browser: https://github.com/kilobyte/qjoypad/tree/debian

--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ Standards-Version: 4.4.1
 Rules-Requires-Root: no
 Homepage: https://github.com/panzi/qjoypad
 Vcs-Browser: https://github.com/kilobyte/qjoypad/tree/debian
-Vcs-Git: https://github.com/kilobyte/qjoypad -b debian
+Vcs-Git: https://github.com/kilobyte/qjoypad.git -b debian
 
 Package: qjoypad
 Architecture: linux-any

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/panzi/qjoypad/issues
+Bug-Submit: https://github.com/panzi/qjoypad/issues/new
+Repository: https://github.com/panzi/qjoypad.git
+Repository-Browse: https://github.com/panzi/qjoypad


### PR DESCRIPTION
Fix some issues reported by lintian
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))
* Use canonical URL in Vcs-Git. ([vcs-field-not-canonical](https://lintian.debian.org/tags/vcs-field-not-canonical.html))
* Update standards version to 4.5.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/qjoypad/d3e681f0-6d54-4908-b04c-d02dda015d63.


## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/fb/6d95f926b02712c1836434e9da8deb30a26df6.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/43/cfa013eccdb8443b0ee72c55a2d3fd404fbb14.debug
### Control files of package qjoypad: lines which differ (wdiff format)
* Depends: libc6 (>= 2.27), libgcc-s1 (>= 3.0), libqt5core5a (>= 5.12.2), libqt5gui5 (>= 5.7.0) | libqt5gui5-gles (>= 5.7.0), libqt5widgets5 (>= 5.0.2), libqt5x11extras5 (>= 5.6.0), libstdc++6 (>= [-5),-] {+4.1.1),+} libudev1 (>= 183), libx11-6, libxtst6
### Control files of package qjoypad-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-43cfa013eccdb8443b0ee72c55a2d3fd404fbb14-] {+fb6d95f926b02712c1836434e9da8deb30a26df6+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/d3e681f0-6d54-4908-b04c-d02dda015d63/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/d3e681f0-6d54-4908-b04c-d02dda015d63/diffoscope)).
